### PR TITLE
Fix lifecycle_data issue

### DIFF
--- a/tasks/build_cv_keep_list.yml
+++ b/tasks/build_cv_keep_list.yml
@@ -13,8 +13,7 @@
   set_fact:
     cv_keep_list: "{{ keep_qry }}"
   vars:
-    keep_count: ":{{ cv.keep_content_view_versions_count }}"
-    keep_qry: "{{ '{{' }} cv_ver_names[{{ keep_count }}] {{ '}}' }}"
+    keep_qry: "{{ cv_ver_names[:cv.keep_content_view_versions_count] }}"
 
 - debug:
     var: "cv_keep_list"

--- a/tasks/build_promotion_list.yml
+++ b/tasks/build_promotion_list.yml
@@ -10,7 +10,7 @@
 - name: "Set lifecycle ID"
   set_fact:
     lifecycle_id: "[{{ lifecycle_qry.json | json_query(lc_id_jq) | join('') }}]"
-    lifecycle_data: "[{{ lifecycle_qry.json | json_query(lc_data_jq) | join('') }}]"
+    lifecycle_data: "[{{ lifecycle_qry.json | json_query(lc_data_jq) | join(',) }}]"
   vars:
     lc_id_jq: "results[?name==`{{ lifecycle }}`].id"
     lc_data_jq: "results[?name==`{{ lifecycle }}`].{id: id, name: name}"

--- a/tasks/build_promotion_list.yml
+++ b/tasks/build_promotion_list.yml
@@ -10,7 +10,7 @@
 - name: "Set lifecycle ID"
   set_fact:
     lifecycle_id: "[{{ lifecycle_qry.json | json_query(lc_id_jq) | join('') }}]"
-    lifecycle_data: "[{{ lifecycle_qry.json | json_query(lc_data_jq) | join(',) }}]"
+    lifecycle_data: "[{{ lifecycle_qry.json | json_query(lc_data_jq) | join(',') }}]"
   vars:
     lc_id_jq: "results[?name==`{{ lifecycle }}`].id"
     lc_data_jq: "results[?name==`{{ lifecycle }}`].{id: id, name: name}"


### PR DESCRIPTION
When multiple same lifecycle_data name exist, like ex.: Library, task failed with error: `...can only concatenate list (not AnsibleUnsafeText ) to list...`